### PR TITLE
Fixing Bio_install_list  duplicated entries

### DIFF
--- a/packages_install.R
+++ b/packages_install.R
@@ -4,8 +4,7 @@ R_install_list <- c("optparse", "futile.logger", "Seurat", "dplyr",
 
 
 
-Bio_install_list <- c("scMCA", "clusterProfiler", "org.Mm.eg.db", 
-                      "clusterProfiler", "org.Mm.eg.db")
+Bio_install_list <- c("scMCA", "clusterProfiler", "org.Mm.eg.db")
 
 
 failed_vec <- c()


### PR DESCRIPTION
Also, 'scMCA' has to be installed through 'devtools'.

Should package installation have the option to be done locally?
eg.:
`local_lib = '/home/userXXXX/software/R_libs'`
`.libPaths(c(local_lib, .libPaths()))`
`install.packages(a_package, repos = "http://cran.us.r-project.org", lib = local_lib)`
`BiocManager::install(a_package, lib = local_lib)`