### PR TITLE
Fixing generate_scrna_ExternalAnnotation species annotation

### DIFF
--- a/data_factory.R
+++ b/data_factory.R
@@ -909,7 +909,7 @@ generate_scrna_ExternalAnnotation <- function(scrna){
        if(length(score) == 0){ 
            return("Unknown") 
        }   
-       sdf <- df[df$Mouse.Gene %in% names(score), c(glue("{SPECIES}.Gene"), "Cell.Type")] 
+       sdf <- df[df[,glue("{SPECIES}.Gene")] %in% names(score), c(glue("{SPECIES}.Gene"), "Cell.Type")] 
        sdf$score <- score[sdf[,glue("{SPECIES}.Gene")]] 
        itype <- aggregate(sdf$score, by=list(CellType=sdf$Cell.Type), 
                           FUN=function(x){return(mean(x)*log(length(x)+1))})


### PR DESCRIPTION
In function '**generate_scrna_ExternalAnnotation**', *sdf* was created as a subset of *df$Mouse.Gene* (rows) independently of the selected species.


If used with human data this could lead to a 0-row matrix and subsequently, an error.