### PR TITLE
fixing double sep in savedir

### DIFF
--- a/viz/template/DE-GO-1v1.template
+++ b/viz/template/DE-GO-1v1.template
@@ -68,7 +68,7 @@ GeneBarPlot <- function(de.data, xlim = NULL, main = NULL) {
 }
 
 #savedir <- "save/save-{{CC}}"
-savedir <- "../save/"
+savedir <- "../save"
 scrna <- readRDS(file.path(savedir, "scrna_dego_name.Rds"))
 
 cluster_use <- params$cluster


### PR DESCRIPTION
file.path function adds OS specific separator, in its current form, savedir would lead to "../save//a_file".