### PR TITLE
Adding much faster and better compression options for RDS objects.

### DIFF
--- a/R/save_load_helper.R
+++ b/R/save_load_helper.R
@@ -1,0 +1,29 @@
+
+suppressPackageStartupMessages(library(archive))
+
+save_object <- function(object, file_name, file_format=NULL){
+
+  stopifnot(file_format %in% c("zstd", "lz4", "gzip", "bzip2", "xz", "nocomp"))
+
+  if(file_format %in% "nocomp"){
+    saveRDS(object = object, file = file_name, compress = FALSE)
+    return(invisible(NULL))
+  }
+
+  if(file_format %in% c("zstd", "lz4")){
+    con <- archive::file_write(file = file_name, filter = file_format)
+    open(con)
+    saveRDS(object = object, file = con)
+    close(con)
+  }else{
+    saveRDS(object = object, file = file_name, compress = file_format)
+  }
+}
+
+load_object <- function(file_name){
+  con <- archive::file_read(file = file_name)
+  res <- readRDS(file = con)
+  close(con)
+  return(res)
+}
+

--- a/data_factory.R
+++ b/data_factory.R
@@ -52,7 +52,6 @@ AllOptions <- function(){
                        help="min nCount_RNA [default %default]",
                        metavar="number")
 
-
   parser <- add_option(parser, c("--nCountRNAceiling"), type="character", default=40000,
                        help="max nCount_RNA [default %default]",
                        metavar="number")
@@ -104,8 +103,15 @@ AllOptions <- function(){
                        help="dims keep to do clustering using harmony [default %default]",
                        metavar="character")
 
-
-
+  parser <- add_option(
+    parser, c("-z", "--compression"),
+    type = "character", default = "gzip", metavar = "character",
+    help = paste0(
+      "Compression algorithm to use when saving R objects [default %default]. ",
+      "One of 'zstd', 'lz4', 'gzip', 'bzip2', ",
+      "'xz' or 'nocomp' (no compression)"
+    )
+  )
 
   return(parser)
 }
@@ -125,6 +131,8 @@ FINDNEIGHBORS_DIM     = eval(parse(text=pa$Dims4FindNeighbors))
 CLUSTER_RESOLUTION    = pa$clusterresolution
 DEFUALT_CLUSTER_NAME  = pa$defaultclustername
 CM_FORMAT             = pa$countmatrixformat
+COMPRESSION_FORMAT    = pa$compression
+
 f = function(x){if(x == ""){ return("")}else{ return("-")}}
 LOGNAME               = paste0(pa$logname, f(pa$logname))
 
@@ -205,6 +213,7 @@ if(!file.exists(pa$configfile)){
 }
 
 source(pa$configfile)
+source("R/save_load_helper.R")
 
 ##--------------Load the function scripts----------------------
 R_scripts <- list.files("R_scripts/", full.name = TRUE)
@@ -259,7 +268,15 @@ plan_record <- function(plan){
   }
 }
 
-
+# setup function to save object to debug for ease of use
+debug_save_stop <- function(scrna,key){
+  save_object(
+    object = scrna,
+    file_name = file.path(SAVE_DIR, "scrna_for_debug.Rds"),
+    file_format = COMPRESSION_FORMAT
+  )
+  stop(glue("ERROR when run {key}"))
+}
 
 ## executing plan
 conf = conf[conf > 0]
@@ -339,7 +356,7 @@ conf_main <- function(){
       # do nothing
     }else if(val==2){
       logger.info(paste("loading", NRds))
-      scrna <- readRDS(file=file.path(SAVE_DIR, NRds))
+      scrna <- load_object(file_name = file.path(SAVE_DIR, NRds))
       scrna@tools$parameter[[cur_time]] <- unlist(pa)
       scrna@tools$execution[[cur_time]] <- conf
       scrna <- sanity_function(scrna, key)
@@ -352,20 +369,26 @@ conf_main <- function(){
         ret_list <-  eval(parse(text=func_call))
         scrna  <- ret_list[[1]]
         ret_code <- ret_list[[2]]
-	scrna <- sanity_function(scrna, key)
-        if(ret_code != 0){
-          saveRDS(scrna, glue("{SAVE_DIR}/scrna_for_debug.Rds"))
-          stop(glue("ERROR when run {key}"))
-        }
+        scrna <- sanity_function(scrna, key)
+
+        if(ret_code != 0){ debug_save_stop(scrna, key) }
+
         #if("meta_order" %ni% names(scrna@tools)){
-        scrna@tools[["meta_order"]] <- list(name = names(data_src), stage=unique(stage_lst))
+        scrna@tools[["meta_order"]] <- list(
+          name = names(data_src),
+          stage = unique(stage_lst)
+        )
         #}
         phase_name <- get_output_name(scrna, key) ### only first store, or second time
-        saveRDS(scrna, file=file.path(SAVE_DIR, glue("{phase_name}.Rds")))
+        save_object(
+          object = scrna,
+          file_name = file.path(SAVE_DIR, glue("{phase_name}.Rds")),
+          file_format = COMPRESSION_FORMAT
+        )
         logger.info(paste("finished", phase_name))
       }
     }else{
-      logger.error("Wrong setting in config file in section RUN PARAMETERS\n Only 0 1 2 permitted")
+      logger.error("Wrong settings in config file in section RUN PARAMETERS\n Only 0, 1 or 2 permitted")
       logger.error(traceback())
       stop("Exit 1")
     }
@@ -570,26 +593,28 @@ generate_scrna_phase_singleton <- function(scrna){
 
 
   for (key in names(pconf)){
-      f_name = paste("generate_", key, sep="")
-      f_call = paste(f_name, "(scrna)", sep="")
-      logger.info(paste("executing", f_name))
-      ret_list <-  eval(parse(text=f_call))
-      scrna  <- ret_list[[1]]
-      ret_code <- ret_list[[2]]
-      scrna <- sanity_function(scrna, key)
-      if(ret_code != 0){
-          saveRDS(scrna, glue("{SAVE_DIR}/scrna_for_debug.Rds"))
-          stop(glue("ERROR when run {key}"))
-      }
-      if(key == "scrna_rawdata"){
-          scrna@tools$parameter[[cur_time]] <- unlist(pa)
-          scrna@tools$execution[[cur_time]] <- conf
-          NRds = paste0(key, ".Rds")
-          saveRDS(scrna, file=file.path(SAVE_DIR, NRds))
-      }
-      logger.info(paste("finished", f_name))
+    f_name = paste("generate_", key, sep="")
+    f_call = paste(f_name, "(scrna)", sep="")
+    logger.info(paste("executing", f_name))
+    ret_list <-  eval(parse(text=f_call))
+    scrna  <- ret_list[[1]]
+    ret_code <- ret_list[[2]]
+    scrna <- sanity_function(scrna, key)
 
-   }
+    if(ret_code != 0){ debug_save_stop(scrna, key) }
+
+    if(key == "scrna_rawdata"){
+      scrna@tools$parameter[[cur_time]] <- unlist(pa)
+      scrna@tools$execution[[cur_time]] <- conf
+      NRds = paste0(key, ".Rds")
+      save_object(
+        object = scrna,
+        file_name = file.path(SAVE_DIR, NRds),
+        file_format = COMPRESSION_FORMAT
+      )
+    }
+    logger.info(paste("finished", f_name))
+  }
   return(list(scrna, ret_code))
 }
 
@@ -603,26 +628,28 @@ generate_scrna_phase_preprocess <- function(scrna){
 
 
   for (key in names(pconf)){
-      f_name = paste("generate_", key, sep="")
-      f_call = paste(f_name, "(scrna)", sep="")
-      logger.info(paste("executing", f_name))
-      ret_list <-  eval(parse(text=f_call))
-      scrna  <- ret_list[[1]]
-      ret_code <- ret_list[[2]]
-      scrna <- sanity_function(scrna, key)
-      if(ret_code != 0){
-          saveRDS(scrna, glue("{SAVE_DIR}/scrna_for_debug.Rds"))
-          stop(glue("ERROR when run {key}"))
-      }
-      if(key == "scrna_rawdata"){
-          scrna@tools$parameter[[cur_time]] <- unlist(pa)
-          scrna@tools$execution[[cur_time]] <- conf
-          NRds = paste0(key, ".Rds")
-          saveRDS(scrna, file=file.path(SAVE_DIR, NRds))
-      }
-      logger.info(paste("finished", f_name))
+    f_name = paste("generate_", key, sep="")
+    f_call = paste(f_name, "(scrna)", sep="")
+    logger.info(paste("executing", f_name))
+    ret_list <-  eval(parse(text=f_call))
+    scrna  <- ret_list[[1]]
+    ret_code <- ret_list[[2]]
+    scrna <- sanity_function(scrna, key)
 
-   }
+    if(ret_code != 0){ debug_save_stop(scrna, key) }
+
+    if(key == "scrna_rawdata"){
+      scrna@tools$parameter[[cur_time]] <- unlist(pa)
+      scrna@tools$execution[[cur_time]] <- conf
+      NRds = paste0(key, ".Rds")
+      save_object(
+        object = scrna,
+        file_name = file.path(SAVE_DIR, NRds),
+        file_format = COMPRESSION_FORMAT
+      )
+    }
+    logger.info(paste("finished", f_name))
+  }
   return(list(scrna, ret_code))
 }
 
@@ -640,10 +667,9 @@ generate_scrna_phase_clustering <- function(scrna){
       scrna  <- ret_list[[1]]
       ret_code <- ret_list[[2]]
       scrna <- sanity_function(scrna, key)
-      if(ret_code != 0){
-          saveRDS(scrna, glue("{SAVE_DIR}/scrna_for_debug.Rds"))
-          stop(glue("ERROR when run {key}"))
-      }
+
+      if(ret_code != 0){ debug_save_stop(scrna, key) }
+
       logger.info(paste("finished", f_name))
 
    }
@@ -684,12 +710,10 @@ generate_scrna_phase_existed_clusters <- function(scrna){
       scrna  <- ret_list[[1]]
       ret_code <- ret_list[[2]]
       scrna <- sanity_function(scrna, key)
-      if(ret_code != 0){
-          saveRDS(scrna, glue("{SAVE_DIR}/scrna_for_debug.Rds"))
-          stop(glue("ERROR when run {key}"))
-      }
-      logger.info(paste("finished", f_name))
 
+      if(ret_code != 0){ debug_save_stop(scrna, key) }
+
+      logger.info(paste("finished", f_name))
    }
   return(list(scrna, ret_code))
 }
@@ -708,10 +732,9 @@ generate_scrna_phase_comparing <- function(scrna){
       scrna  <- ret_list[[1]]
       ret_code <- ret_list[[2]]
       scrna <- sanity_function(scrna, key)
-      if(ret_code != 0){
-          saveRDS(scrna, glue("{SAVE_DIR}/scrna_for_debug.Rds"))
-          stop(glue("ERROR when run {key}"))
-      }
+
+      if(ret_code != 0){ debug_save_stop(scrna, key) }
+
       logger.info(paste("finished", f_name))
    }
   return(list(scrna, ret_code))
@@ -1317,7 +1340,7 @@ generate_scrna_remove_recluster <- function(scrna){
     scrna <- ret_list[[1]]
     ret_code <- ret_list[[2]]
     if(ret_code != 0){
-     return(list(scrna, ret_code))
+      return(list(scrna, ret_code))
     }
   }
   scrna$remove_recluster <- scrna$seurat_clusters
@@ -1337,7 +1360,7 @@ generate_scrna_remove_recluster <- function(scrna){
     scrna <- ret_list[[1]]
     ret_code <- ret_list[[2]]
     if(ret_code != 0){
-     return(list(scrna, ret_code))
+      return(list(scrna, ret_code))
     }
   }
   return(list(scrna, ret_code))
@@ -1743,7 +1766,11 @@ generate_scrna_dego_stage_vsRest <- function(scrna){
                             return(de.list)
            }, mc.cores=1)
 
-  saveRDS(all_de_list, file.path(SAVE_DIR,"all_de_list.Rds"))
+  save_object(
+    object = all_de_list,
+    file_name = file.path(SAVE_DIR,"all_de_list.Rds"),
+    file_format = COMPRESSION_FORMAT
+  )
   names(all_de_list) <- sapply(lst, function(x) paste0(x, ".vs.Rest") )
 
   for(nm in names(all_de_list)) {
@@ -2411,7 +2438,6 @@ get_hallmark_up <- function(de.list){
     }
 
     hallmark <- enricher(genes_e$ENTREZID, TERM2GENE=m_t2g, pvalueCutoff=1)
-
     hallmark <- setReadable(hallmark, orgdb, keyType = "ENTREZID")
     hallmark.up.list[[id]] = hallmark
   }
@@ -2453,7 +2479,6 @@ get_hallmark_down <- function(de.list){
     genes.sorted = NULL
 
     tryCatch({
-
       genes.sorted <- genes[order(pvals)][1:min(100, length(genes))]
       genes_e <- bitr(genes.sorted, fromType="SYMBOL", toType=c("ENTREZID","ENSEMBL"), OrgDb=orgdb);
     }, error = function(cond) {
@@ -2469,12 +2494,12 @@ get_hallmark_down <- function(de.list){
     m_t2g <- msigdbr(species = hallmarkorgan, category = "H") %>%
       dplyr::select(gs_name, entrez_gene)
 
-
     if(length(intersect(genes_e$ENTREZID,  m_t2g$entrez_gene)) == 0){
       hallmark.down.list[(id)] = list(NULL)
       print("null")
       next
     }
+
     hallmark <- enricher(genes_e$ENTREZID, TERM2GENE=m_t2g, pvalueCutoff=1)
     hallmark <- setReadable(hallmark, orgdb, keyType = "ENTREZID")
     hallmark.down.list[[id]] = hallmark
@@ -2525,9 +2550,9 @@ get_pathway_comparison <- function(scrna, slot){
     reactome_downs <- get_reactome_down(de.list)
     all_reactomedown_list[[nm]] <- reactome_downs
 
-    pathway_dump(nm, "KEGG" ,kegg_ups, kegg_downs)
-    pathway_dump(nm, "hallmark" ,hallmark_ups, hallmark_downs)
-    pathway_dump(nm, "Reactome" ,reactome_ups, reactome_downs)
+    pathway_dump(nm, "KEGG", kegg_ups, kegg_downs)
+    pathway_dump(nm, "hallmark", hallmark_ups, hallmark_downs)
+    pathway_dump(nm, "Reactome", reactome_ups, reactome_downs)
   }
   store_list <- list(all_keggup_list, all_keggdown_list,
                      all_hallmarkup_list, all_hallmarkdown_list,
@@ -2604,7 +2629,16 @@ generate_scrna_doublet_proportions <- function(scrna){
     pK_optimal <- lapply(X = bcmvn_lst, FUN = function(x){as.numeric(as.character(x[x$BCmetric == max(x$BCmetric),2]))})
     est_expected <- lapply(X = names(bcmvn_lst), FUN = mc_est_expected, scrnas = scrna_lst, doublet_rate = doublet_formation_rate)
     est_expected <- unlist(est_expected)
-    scrna_list_doublets <- lapply(X = names(bcmvn_lst), FUN = mc_doubletFinder_v3, seurats = scrna_lst, pN = 0.25, pK_optimal = pK_optimal, est_expected = est_expected)
+
+    scrna_list_doublets <- lapply(
+      X = names(bcmvn_lst),
+      FUN = mc_doubletFinder_v3,
+      seurats = scrna_lst,
+      pN = 0.25,
+      pK_optimal = pK_optimal,
+      est_expected = est_expected
+    )
+
     names(scrna_list_doublets) <- names(bcmvn_lst)
     classifications <- c()
     cells <- c()
@@ -2627,7 +2661,12 @@ generate_scrna_doublet_proportions <- function(scrna){
     scrna_save <- ScaleData(scrna_save, verbose = FALSE)
     scrna_save <- RunPCA(scrna_save, npcs = 30, verbose = FALSE, reduction.name="DOUBLET_PCA")
     scrna_save <- RunUMAP(scrna_save, reduction = "DOUBLET_PCA", dims = 1:20, reduction.name="DOUBLET_UMAP")
-    saveRDS(scrna_save, file.path(SAVE_DIR, "scrna_DoubletAnnotated.Rds"))
+
+    save_object(
+      object = scrna_save,
+      file_name = file.path(SAVE_DIR, "scrna_DoubletAnnotated.Rds"),
+      file_format = COMPRESSION_FORMAT
+    )
   }
   if(doublet_switch == "on"){
     scrna <- subset(scrna, Doublet_classifications == "Singlet")

--- a/run_example.sh
+++ b/run_example.sh
@@ -41,8 +41,10 @@ date
 ## 50 cores run, future memory
 mkdir -p ${data_path}/${proj_name}
 ln -s ${data_path}/conf/config_${proj_name}.R ${data_path}/${proj_name}
-Rscript data_factory.R -n 24 \
+Rscript data_factory.R \
+  -n 24 \
   --MaxMemMega=180000 \
+  -z "lz4" \
   -c "./conf/config_${proj_name}.R" \
   -s "${data_path}/${proj_name}/save" \
   -e "${data_path}/${proj_name}/charts" \

--- a/run_viz_example.sh
+++ b/run_viz_example.sh
@@ -72,7 +72,7 @@ date
 Rscript ./viz/create_report.R \
 	-a "Mingbo" \
 	-p ${proj_name} \
-	-m TRUE\
+	-m TRUE \
 	-s "${data_path}/${proj_name}/save" \
 	-c "./conf/config_${proj_name}.R" \
 	-o "${data_path}/${proj_name}/report" \
@@ -80,7 +80,8 @@ Rscript ./viz/create_report.R \
 	-e ./external/Human_and_mouse_cell_markers-Markers.tsv \
   -d "$cluster" \
   -j "${json_exe_list}" \
-  -i "FALSE"
+  -i "FALSE" \
+  -z "lz4"
 date
 
 

--- a/viz/1_quality_report.Rmd
+++ b/viz/1_quality_report.Rmd
@@ -38,13 +38,13 @@ library(kableExtra)
 knitr::include_graphics(file.path(params$report_plots_folder_png,"prefilter_vlnplot.png"))
 ```
 ```{r prefilter_stSample_stCond, echo=FALSE}
-stSample <- readRDS(file.path(params$report_tables_folder,"stSample_prefilter.RDS"))
+stSample <- load_object(file.path(params$report_tables_folder,"stSample_prefilter.RDS"))
 
 stSample %>%
   kable(caption = "Mean and median for each sample", align = 'c') %>%
   kable_styling(bootstrap_options = c("striped", "hover"))
 
-stCond <- readRDS(file.path(params$report_tables_folder,"stCond_prefilter.RDS"))
+stCond <- load_object(file.path(params$report_tables_folder,"stCond_prefilter.RDS"))
 
 stCond %>%
   kable(caption = "Mean and median for each condition", align = 'c') %>%
@@ -65,12 +65,12 @@ knitr::include_graphics(file.path(params$report_plots_folder_png,"postfilter_cel
 
 
 ```{r postfilter_stSample_stCond, echo=FALSE}
-stSample <- readRDS(file.path(params$report_tables_folder,"stSample_postfilter.RDS"))
+stSample <- load_object(file.path(params$report_tables_folder,"stSample_postfilter.RDS"))
 stSample %>%
   kable(caption = "Mean and median for each sample", align = 'c') %>%
   kable_styling(bootstrap_options = c("striped", "hover"))
 
-stCond <- readRDS(file.path(params$report_tables_folder,"stCond_postfilter.RDS"))
+stCond <- load_object(file.path(params$report_tables_folder,"stCond_postfilter.RDS"))
 stCond %>%
   kable(caption = "Mean and median for each condition", align = 'c') %>%
   kable_styling(bootstrap_options = c("striped", "hover"))

--- a/viz/1_quality_report_elements.R
+++ b/viz/1_quality_report_elements.R
@@ -2,7 +2,8 @@
 # pre filtering
 ####################################################
 quality_report_elements <- function(){
-  scrna <- readRDS(file = file.path(savedir, "scrna_rawdata.Rds"))
+
+  scrna <- load_object(file_name = file.path(savedir, "scrna_rawdata.Rds"))
 
   Idents(object = scrna) <- "name"
 
@@ -39,7 +40,11 @@ quality_report_elements <- function(){
       pctRb.Median = median(percent.ribo),
       Cells = sum(cells)
     )
-  saveRDS(stSample,file.path(report_tables_folder,"stSample_prefilter.RDS"))
+  save_object(
+    stSample,
+    file.path(report_tables_folder,"stSample_prefilter.RDS"),
+    COMPRESSION_FORMAT
+  )
 
   stCond <- meta %>%
     group_by(stage) %>%
@@ -54,16 +59,19 @@ quality_report_elements <- function(){
       pctRb.Median = median(percent.ribo),
       Cells = sum(cells)
     )
-  saveRDS(stCond,file.path(report_tables_folder,"stCond_prefilter.RDS"))
-
+  save_object(
+    stCond,
+    file.path(report_tables_folder,"stCond_prefilter.RDS"),
+    COMPRESSION_FORMAT
+  )
 
   ####################################################
   # post filtering
   ####################################################
   if(identical(cluster,"singleton")){
-    scrna <- readRDS(file=file.path(savedir, "scrna_phase_singleton.Rds"))
+    scrna <- load_object(file_name = file.path(savedir, "scrna_phase_singleton.Rds"))
   }else{
-    scrna <- readRDS(file = file.path(savedir, "scrna_phase_preprocess.Rds"))
+    scrna <- load_object(file_name = file.path(savedir, "scrna_phase_preprocess.Rds"))
   }
 
   Idents(object = scrna)<- "name"
@@ -124,7 +132,11 @@ quality_report_elements <- function(){
       pctRb.Median = median(percent.ribo),
       Cells = sum(cells)
     )
-  saveRDS(stSample,file.path(report_tables_folder,"stSample_postfilter.RDS"))
+  save_object(
+    stSample,
+    file.path(report_tables_folder,"stSample_postfilter.RDS"),
+    COMPRESSION_FORMAT
+  )
 
   stCond <- meta %>%
     group_by(stage) %>%
@@ -139,7 +151,11 @@ quality_report_elements <- function(){
       pctRb.Median = median(percent.ribo),
       Cells = sum(cells)
     )
-  saveRDS(stCond,file.path(report_tables_folder,"stCond_postfilter.RDS"))
+  save_object(
+    stCond,
+    file.path(report_tables_folder,"stCond_postfilter.RDS"),
+    COMPRESSION_FORMAT
+  )
 
 
 

--- a/viz/2_batch_clustering_elements.R
+++ b/viz/2_batch_clustering_elements.R
@@ -2,10 +2,9 @@
 batch_clustering_elements <- function(scrna){
   ## Clusters Resolution
   if(identical(cluster,"singleton")){
-    # scrna <- readRDS(file=file.path(savedir, "scrna_singleton_markergenes.Rds"))
-    scrna <- readRDS(file=file.path(savedir, "scrna_phase_singleton.Rds"))
+    scrna <- load_object(file_name = file.path(savedir, "scrna_phase_singleton.Rds"))
   }else{
-    scrna <- readRDS(file=file.path(savedir, "scrna_phase_comparing.Rds"))
+    scrna <- load_object(file_name = file.path(savedir, "scrna_phase_comparing.Rds"))
   }
 
   for(cluster_use in available_clusters){

--- a/viz/2_clustering.Rmd
+++ b/viz/2_clustering.Rmd
@@ -61,7 +61,7 @@ knitr::include_graphics(
 )
 ```
 ```{r stSample_stCond_table_cluster, echo=FALSE}
-readRDS(
+load_object(
   file.path(
     params$report_tables_folder,
     paste0("stSample_table_cluster_",params$cluster,".RDS")
@@ -70,7 +70,7 @@ readRDS(
   kable(caption = "samples: cluster cells", align = 'c') %>%
   kable_styling(bootstrap_options = c("striped", "hover"))
 
-readRDS(
+load_object(
   file.path(
     params$report_tables_folder,
     paste0("stCond_table_cluster_",params$cluster,".RDS")
@@ -162,13 +162,13 @@ fname <- file.path(
 if(file.exists(fname)) knitr::include_graphics(fname)
 ```
 ```{r mca_annotate_hover, out.width="100%", echo=FALSE, eval=(FALSE & params$cluster!="singleton")}
-plt = readRDS(
+plt = load_object(
   file.path(
     params$report_plots_folder,
     paste0("mca_annotate_plt_",params$cluster,".RDS")
   )
 )
-info = readRDS(
+info = load_object(
   file.path(
     params$report_plots_folder,
     paste0("mca_annotate_info_",params$cluster,".RDS")
@@ -186,13 +186,13 @@ fname <- file.path(
 if(file.exists(fname)) knitr::include_graphics(fname)
 ```
 ```{r hcl_annotate_hover, out.width="100%", echo=FALSE, eval=(FALSE & params$cluster!="singleton")}
-plt = readRDS(
+plt = load_object(
   file.path(
     params$report_plots_folder,
     paste0("hcl_annotate_plt_",params$cluster,".RDS")
   )
 )
-info = readRDS(
+info = load_object(
   file.path(
     params$report_plots_folder,
     paste0("hcl_annotate_info_",params$cluster,".RDS")
@@ -210,13 +210,13 @@ fname <- file.path(
 if(file.exists(fname)) knitr::include_graphics(fname)
 ```
 ```{r external_annotation_hover, out.width="100%", echo=FALSE, eval=(FALSE & params$cluster!="singleton")}
-plt = readRDS(
+plt = load_object(
   file.path(
     params$report_plots_folder,
     paste0("external_annotation_plt_",params$cluster,".RDS")
   )
 )
-info = readRDS(
+info = load_object(
   file.path(
     params$report_plots_folder,
     paste0("external_annotation_info_",params$cluster,".RDS")

--- a/viz/2_clustering_elements.R
+++ b/viz/2_clustering_elements.R
@@ -78,9 +78,10 @@ clustering_elements <- function(scrna){
     tbl <- cbind(tbl, rowsums)
     colsums <- colSums(tbl)
     tbl <- rbind(tbl, colsums)
-    saveRDS(
+    save_object(
       tbl,
-      file.path(report_tables_folder, paste0("stSample_table_cluster_",cluster_use,".RDS"))
+      file.path(report_tables_folder, paste0("stSample_table_cluster_",cluster_use,".RDS")),
+      COMPRESSION_FORMAT
     )
 
     tbl <- table(scrna$stage, scrna@meta.data[, cluster_use])
@@ -88,9 +89,10 @@ clustering_elements <- function(scrna){
     tbl <- cbind(tbl, rowsums)
     colsums <- colSums(tbl)
     tbl <- rbind(tbl, colsums)
-    saveRDS(
+    save_object(
       tbl,
-      file.path(report_tables_folder, paste0("stCond_table_cluster_",cluster_use,".RDS"))
+      file.path(report_tables_folder, paste0("stCond_table_cluster_",cluster_use,".RDS")),
+      COMPRESSION_FORMAT
     )
 
     if(cluster_use != "singleton"){
@@ -383,10 +385,15 @@ clustering_elements <- function(scrna){
 
       # also save plot and information as rds so that it can be later rendered in the report as plotly
       message("### Saving MCA annotation data to produce plotly in report")
-      saveRDS(plt,file.path(savedir,paste0("mca_annotate_plt_",cluster_use,".RDS")))
-      saveRDS(
+      save_object(
+        plt,
+        file.path(savedir,paste0("mca_annotate_plt_",cluster_use,".RDS")),
+        COMPRESSION_FORMAT
+      )
+      save_object(
         FetchData(object = tmp_scrna, vars = c("MCA_annotate", cluster_use)),
-        file.path(savedir,paste0("mca_annotate_info_",cluster_use,".RDS"))
+        file.path(savedir,paste0("mca_annotate_info_",cluster_use,".RDS")),
+        COMPRESSION_FORMAT
       )
     }
 
@@ -418,10 +425,15 @@ clustering_elements <- function(scrna){
 
       # also save plot and information as rds so that it can be later rendered in the report as plotly
       message("### Saving HCL annotation data to produce plotly in report")
-      saveRDS(plt,file.path(savedir,paste0("hcl_annotate_plt_",cluster_use,".RDS")))
-      saveRDS(
+      save_object(
+        plt,
+        file.path(savedir,paste0("hcl_annotate_plt_",cluster_use,".RDS")),
+        COMPRESSION_FORMAT
+      )
+      save_object(
         FetchData(object = tmp_scrna, vars = c("HCL_annotate", cluster_use)),
-        file.path(savedir,paste0("hcl_annotate_info_",cluster_use,".RDS"))
+        file.path(savedir,paste0("hcl_annotate_info_",cluster_use,".RDS")),
+        COMPRESSION_FORMAT
       )
     }
 
@@ -451,10 +463,15 @@ clustering_elements <- function(scrna){
         width=9, height=7
       )
       message("### Saving external annotation data to produce plotly in report")
-      saveRDS(plt,file.path(savedir,paste0("external_annotation_plt_",cluster_use,".RDS")))
-      saveRDS(
+      save_object(
+        plt,
+        file.path(savedir,paste0("external_annotation_plt_",cluster_use,".RDS")),
+        COMPRESSION_FORMAT
+      )
+      save_object(
         FetchData(object = tmp_scrna, vars = c("external_annotation", cluster_use)),
-        file.path(savedir,paste0("external_annotation_info_",cluster_use,".RDS"))
+        file.path(savedir,paste0("external_annotation_info_",cluster_use,".RDS")),
+        COMPRESSION_FORMAT
       )
     }
   }

--- a/viz/2_clustering_harmony.Rmd
+++ b/viz/2_clustering_harmony.Rmd
@@ -73,7 +73,7 @@ knitr::include_graphics(
 )
 ```
 ```{r stSample_stCond_table_cluster_harmony, echo=FALSE}
-readRDS(
+load_object(
   file.path(
     params$report_tables_folder,
     paste0("stSample_table_cluster_",fixed_cluster,".RDS")
@@ -82,7 +82,7 @@ readRDS(
   kable(caption = "samples: cluster cells", align = 'c') %>%
   kable_styling(bootstrap_options = c("striped", "hover"))
 
-readRDS(
+load_object(
   file.path(
     params$report_tables_folder,
     paste0("stCond_table_cluster_",fixed_cluster,".RDS")
@@ -181,13 +181,13 @@ fname <- file.path(
 if(file.exists(fname)) knitr::include_graphics(fname)
 ```
 ```{r mca_annotate_hover_harmony, out.width="100%", echo=FALSE, eval=FALSE}
-plt = readRDS(
+plt = load_object(
   file.path(
     params$report_plots_folder,
     paste0("mca_annotate_plt_",fixed_cluster,".RDS")
   )
 )
-info = readRDS(
+info = load_object(
   file.path(
     params$report_plots_folder,
     paste0("mca_annotate_info_",fixed_cluster,".RDS")
@@ -205,13 +205,13 @@ fname <- file.path(
 if(file.exists(fname)) knitr::include_graphics(fname)
 ```
 ```{r external_annotation_hover_harmony, out.width="100%", echo=FALSE, eval=FALSE}
-plt = readRDS(
+plt = load_object(
   file.path(
     params$report_plots_folder,
     paste0("external_annotation_plt_",fixed_cluster,".RDS")
   )
 )
-info = readRDS(
+info = load_object(
   file.path(
     params$report_plots_folder,
     paste0("external_annotation_info_",fixed_cluster,".RDS")

--- a/viz/2_clustering_seurat.Rmd
+++ b/viz/2_clustering_seurat.Rmd
@@ -72,7 +72,7 @@ knitr::include_graphics(
 )
 ```
 ```{r stSample_stCond_table_cluster_seurat, echo=FALSE}
-readRDS(
+load_object(
   file.path(
     params$report_tables_folder,
     paste0("stSample_table_cluster_",fixed_cluster,".RDS")
@@ -81,7 +81,7 @@ readRDS(
   kable(caption = "samples: cluster cells", align = 'c') %>%
   kable_styling(bootstrap_options = c("striped", "hover"))
 
-readRDS(
+load_object(
   file.path(
     params$report_tables_folder,
     paste0("stCond_table_cluster_",fixed_cluster,".RDS")
@@ -182,13 +182,13 @@ fname <- file.path(
 if(file.exists(fname)) knitr::include_graphics(fname)
 ```
 ```{r mca_annotate_hover_seurat, out.width="100%", echo=FALSE, eval=FALSE}
-plt = readRDS(
+plt = load_object(
   file.path(
     params$report_plots_folder,
     paste0("mca_annotate_plt_",fixed_cluster,".RDS")
   )
 )
-info = readRDS(
+info = load_object(
   file.path(
     params$report_plots_folder,
     paste0("mca_annotate_info_",fixed_cluster,".RDS")
@@ -206,13 +206,13 @@ fname <- file.path(
 if(file.exists(fname)) knitr::include_graphics(fname)
 ```
 ```{r external_annotation_hover_seurat, out.width="100%", echo=FALSE, eval=FALSE}
-plt = readRDS(
+plt = load_object(
   file.path(
     params$report_plots_folder,
     paste0("external_annotation_plt_",fixed_cluster,".RDS")
   )
 )
-info = readRDS(
+info = load_object(
   file.path(
     params$report_plots_folder,
     paste0("external_annotation_info_",fixed_cluster,".RDS")

--- a/viz/3_external_markers.Rmd
+++ b/viz/3_external_markers.Rmd
@@ -26,7 +26,7 @@ author: '`r params$author`'
 
 ```{r ext_markers_setup, include=FALSE}
 knitr::opts_chunk$set(warning = F, message = F, echo = T)
-celltype_names = readRDS(file.path(params$report_tables_folder, "ext_annot_celltype_names.RDS"))
+celltype_names = load_object(file.path(params$report_tables_folder, "ext_annot_celltype_names.RDS"))
 ```
 
 ## External markers

--- a/viz/3_external_markers_elements.R
+++ b/viz/3_external_markers_elements.R
@@ -25,9 +25,10 @@ external_markers_elements <- function(scrna){
 
   mdf = df[df$Tissue.of.Origin == ORGAN, c(glue("{SPECIES}.Gene"), "Cell.Type")]
   celltype_names <- unique(mdf$Cell.Type)
-  saveRDS(
-    celltype_names,
-    file = file.path(report_tables_folder, "ext_annot_celltype_names.RDS")
+  save_object(
+    object = celltype_names,
+    file_name = file.path(report_tables_folder, "ext_annot_celltype_names.RDS"),
+    file_format = COMPRESSION_FORMAT
   )
 
   ## External markers

--- a/viz/ambientRNA_viz.Rmd
+++ b/viz/ambientRNA_viz.Rmd
@@ -27,18 +27,8 @@ author: '`r params$author`'
 knitr::opts_chunk$set(warning = F, message = F, echo = F,cache=F)
 library(dplyr)
 library(kableExtra)
-savedir = params$savedir
-```
-```{r , include=FALSE}
-#library(celda)
 library(ggplot2)
-#scrna.sce <- readRDS(file = file.path(savedir, "scrnasce_ambient_rna.Rds"))
-#scrna <- readRDS(file = file.path(savedir, "/scrna_phase_preprocess.Rds"))
-#plt <- list()
-
-#plt[[1]] <- FeaturePlot(scrna, features = "AmbientRNA") + ggtitle(label = "Ambient RNA Contamintaion")
-
-#plt[[2]] <- VlnPlot(object = scrna, features = "AmbientRNA", group.by = "decontX_clusters")
+savedir = params$savedir
 ```
 
 ## Ambient RNA
@@ -54,7 +44,7 @@ knitr::include_graphics(file.path(params$report_plots_folder_png,"ambient_rna_vl
 ```
 
 ```{r postfilter_ambientRNA, echo=FALSE}
-stSample <- readRDS(file.path(params$report_tables_folder, "ambientRNA_postfilter.RDS"))
+stSample <- load_object(file.path(params$report_tables_folder, "ambientRNA_postfilter.RDS"))
 stSample %>%
   kable(caption = "Mean and median ambient RNA for each sample", align = 'c') %>%
   kable_styling(bootstrap_options = c("striped", "hover"))

--- a/viz/ambientRNA_viz_elements.R
+++ b/viz/ambientRNA_viz_elements.R
@@ -48,9 +48,10 @@ ambientRNA_elements <- function(scrna){
       ambientRNA.Mean = mean(AmbientRNA),
       ambientRNA.Median = median(AmbientRNA),
     )
-  saveRDS(
+  save_object(
     stSample,
-    file.path(report_tables_folder, "ambientRNA_postfilter.RDS")
+    file.path(report_tables_folder, "ambientRNA_postfilter.RDS"),
+    COMPRESSION_FORMAT
   )
 }
 

--- a/viz/create_report.R
+++ b/viz/create_report.R
@@ -5,6 +5,8 @@ t_start <- Sys.time()
 source("R/helper_functions.R")
 source("R/DE_GO_VS_helper.R")
 source("R/pathway_vs_helper.R")
+source("R/save_load_helper.R")
+
 
 suppressPackageStartupMessages(library(optparse))      ## Options
 
@@ -59,6 +61,15 @@ AllOptions <- function(){
     parser, c("-i", "--indexonly"), type = "character", default = "FALSE",
     help = "only generate index.html [default %default]", metavar = "character")
 
+  parser <- add_option(
+    parser, c("-z", "--compression"),
+    type = "character", default = "gzip", metavar = "character",
+    help = paste0(
+      "Compression algorithm to use when saving R objects [default %default]. ",
+      "One of 'zstd', 'lz4', 'gzip', 'bzip2', ",
+      "'xz' or 'nocomp' (no compression)"
+    )
+  )
   return(parser)
 }
 
@@ -77,6 +88,7 @@ DEFAULTCLUSTERS   = pa$defaultclsuters
 GEN_SINGLE_FILE   = pa$singlefile
 EXEC_PLAN         = jsonlite::fromJSON(pa$planOfreport)
 INDEX_ONLY        = pa$indexonly
+COMPRESSION_FORMAT= pa$compression
 
 dir.create(file.path(REPORTDIR, "data"), recursive = TRUE)
 
@@ -149,7 +161,9 @@ if(MAKE_ELEMENT){
     cat(
       paste0(date(), blue(" Loading: "), red("scrna_phase_singleton.Rds"), "\n")
     )
-    scrna <- readRDS(file = file.path(savedir, "scrna_phase_singleton.Rds"))
+    scrna <- load_object(
+      file_name = file.path(savedir, "scrna_phase_singleton.Rds")
+    )
     cat(
       paste0(date(), blue(" Loaded: "), red("scrna_phase_singleton.Rds"), "\n")
     )
@@ -157,7 +171,9 @@ if(MAKE_ELEMENT){
     cat(
       paste0(date(), blue(" Loading: "), red("scrna_phase_comparing.Rds"), "\n")
     )
-    scrna <- readRDS(file = file.path(savedir, "scrna_phase_comparing.Rds"))
+    scrna <- load_object(
+      file_name = file.path(savedir, "scrna_phase_comparing.Rds")
+    )
     cat(
       paste0(date(), blue(" Loaded: "), red("scrna_phase_comparing.Rds"), "\n")
     )

--- a/viz/doubletdetection_viz.Rmd
+++ b/viz/doubletdetection_viz.Rmd
@@ -40,7 +40,7 @@ knitr::include_graphics(file.path(params$report_plots_folder_png,"doublets_umap.
 ```
 
 ```{r postfilter_ambientRNA, echo=FALSE}
-stSample <- readRDS(file.path(params$report_tables_folder, "doublets_table.Rds"))
+stSample <- load_object(file.path(params$report_tables_folder, "doublets_table.Rds"))
 stSample %>%
   kable(caption = "Doublets detected for each sample", align = 'c') %>%
   kable_styling(bootstrap_options = c("striped", "hover"))

--- a/viz/doubletdetection_viz_elements.R
+++ b/viz/doubletdetection_viz_elements.R
@@ -9,7 +9,7 @@ doubletdetection_viz_elements <- function(scrna){
   # We can use the output from the doublet detection function (scrna_DoubletAnnotated.Rds) and plot the UMAP we created for this purpose.
   # If doublet_switch == "off", we just put out a message stating that doublet detection was not performed.
   if(doublet_switch == "display"){
-    scrna <- readRDS(file.path(savedir, "scrna_phase_comparing.Rds"))
+    scrna <- load_object(file_name = file.path(savedir, "scrna_phase_comparing.Rds"))
     plt <- DimPlot(scrna, group.by = "Doublet_classifications", reduction = "INTE_UMAP")
     save_ggplot_formats(
       plt=plt,
@@ -18,7 +18,7 @@ doubletdetection_viz_elements <- function(scrna){
       width=9, height=7
     )
   } else if(doublet_switch == "on"){
-    scrna <- readRDS(file.path(savedir, "scrna_DoubletAnnotated.Rds"))
+    scrna <- load_object(file_name = file.path(savedir, "scrna_DoubletAnnotated.Rds"))
     plt <- DimPlot(scrna, group.by = "Doublet_classifications", reduction = "DOUBLET_UMAP")
     save_ggplot_formats(
       plt=plt,
@@ -110,5 +110,10 @@ doubletdetection_viz_elements <- function(scrna){
       Doublets=sum(Doublet_classifications == "Doublet"),
       Singlets=sum(Doublet_classifications == "Singlet")
     )
-  saveRDS(stSample,file.path(report_tables_folder,"doublets_table.Rds"))
+
+  save_object(
+    stSample,
+    file.path(report_tables_folder,"doublets_table.Rds"),
+    COMPRESSION_FORMAT
+  )
 }

--- a/viz/interactive_UMAPs.Rmd
+++ b/viz/interactive_UMAPs.Rmd
@@ -37,13 +37,13 @@ fname <- file.path(
   )
 
 if(file.exists(fname)){
-    plt = readRDS(
+    plt = load_object(
       file.path(
         params$savedir,
         paste0("hcl_annotate_plt_",params$cluster,".RDS")
       )
     )
-    info = readRDS(
+    info = load_object(
       file.path(
         params$savedir,
         paste0("hcl_annotate_info_",params$cluster,".RDS")
@@ -60,13 +60,13 @@ fname <- file.path(
     paste0("mca_annotate_plt_",params$cluster,".RDS")
   )
 if(file.exists(fname)){
-    plt = readRDS(
+    plt = load_object(
       file.path(
         params$savedir,
         paste0("mca_annotate_plt_",params$cluster,".RDS")
       )
     )
-    info = readRDS(
+    info = load_object(
       file.path(
         params$savedir,
         paste0("mca_annotate_info_",params$cluster,".RDS")
@@ -83,13 +83,13 @@ fname <-  file.path(
     paste0("external_annotation_plt_",params$cluster,".RDS")
 )
 if(file.exists(fname)){
-    plt = readRDS(
+    plt = load_object(
       file.path(
         params$savedir,
         paste0("external_annotation_plt_",params$cluster,".RDS")
       )
     )
-    info = readRDS(
+    info = load_object(
       file.path(
         params$savedir,
         paste0("external_annotation_info_",params$cluster,".RDS")

--- a/viz/singleton_clustering.Rmd
+++ b/viz/singleton_clustering.Rmd
@@ -57,7 +57,7 @@ fname <- switch(
   "singleton" = "scrna_singleton_clustering.Rds"
 )
 
-scrna <- readRDS(file=file.path(savedir,fname))
+scrna <- load_object(file_name = file.path(savedir,fname))
 
 clustree(scrna, prefix = "RNA_snn_res.")
 


### PR DESCRIPTION
A major bottleneck in terms of time spent when working with the
pipeline, specifically with large files, is I/O. Saving one of the
pipeline objects, for a given step, can take upwards of 1 hour (default
"saveRDS"). The user can now choose an array of different options in
which to compress their RDS files. We still support the current way
("gzip") but now we can choose much better methods such as "lz4" and "zstd"
which are just much much faster with a small penalty if any regarding
size (see image attached on PR).

The functions "save_object" and "load_object" should, from now on, be the
interfaces through which we save and load RDS objects respectively.

![benchmark_compression_comparison](https://user-images.githubusercontent.com/8191845/129355795-9da880df-afbd-41b7-b6a9-f9713b630c92.png)