### PR TITLE
Changed the preflight check

### DIFF
--- a/data_factory.R
+++ b/data_factory.R
@@ -283,7 +283,7 @@ debug_save_stop <- function(scrna,key){
 ## executing plan
 conf = conf[conf > 0]
 
-if(conf[1] != 2 & (names(conf)[1] %ni% c("scrna_phase_preprocess", "scrna_phase_singleton"))){
+if(conf[1] != 2 & (names(conf)[1] %ni% c("scrna_phase_preprocess", "scrna_phase_singleton", "scrna_rawdata"))){
   logger.error("!!Run without loading data, please check execution plan")
   stop("exit 1")
 }


### PR DESCRIPTION
Previously, the pipeline would require you to start with scrna_phase_preprocess or singleton or by loading the data from a previous run. 

Now, you should be able to start with scrna_rawdata if you want to not use the phases.

This way, you can start a new run from scratch while only using parts of the preprocessing phase.